### PR TITLE
feat context.loaderOverlay, isVisible, overlayWidgetType, improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.2.1
+ - `context.showLoaderOverlay` and `context.hideLoaderOverlay` marked as depricated. You should use `context.loaderOverlay.show` and `context.loaderOverlay.hide`
+ - widget that you pass to `context.loaderOverlay.show` will be shown instead of `widgetOverlay`
+ - Added `context.loaderOverlay.visible`
+ - Added `context.loaderOverlay.overlayWidgetType`
+ - `useDefaultLoading` set to `true` by default
+
 # 1.2.0
 
 - Adding possibility to pass a widget to show underneath the loading indicator

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Have you ever found yourself in the situation of doing some async processing you
 
 # Basic Usage
 
-The most simple usage is just wrap the widget that you want an overlay on LoaderOverlay with the useDefaultLoader set to true.
+The most simple usage is just wrap the widget that you want an overlay on LoaderOverlay. Default loader will be shown.
 
 ```dart
 class MyApp extends StatelessWidget {
@@ -16,7 +16,6 @@ class MyApp extends StatelessWidget {
         primarySwatch: Colors.blue,
       ),
       home: LoaderOverlay(
-        useDefaultLoader: true,
         child: MyHomePage(title: 'Flutter Demo Home Page'),
       ),
     );
@@ -28,17 +27,30 @@ This simple step will already configure the loader overlay for use.
 
 After that configuration you can just run the command:
 
-```
-context.showLoaderOverlay()
+```dart
+context.loaderOverlay.show()
 ```
 
 This will show the overlay with the default loading indicator. The default loading configured is to just show a centered CircularProgressIndicator
 
 To hide the overlay (after the async processing, for example), just run the command:
 
+```dart
+context.loaderOverlay.hide()
 ```
-context.hideLoaderOverlay()
+
+You can check if overlay is visible:
+
+```dart
+final isVisible = context.loaderOverlay.visible
 ```
+
+And get the type of overlay widget:
+
+```dart
+final type = context.loaderOverlay.overlayWidgetType
+```
+
 
 *Note: You will always need the context to show or hide the loader overlay
 
@@ -49,11 +61,10 @@ To use this package with named routes you can just wrap your MaterialApp with Gl
 This widget has all the features of LoaderOverlay but it is provided for all the routes of the app.
 
 
-```
+```dart
 @override
 Widget build(BuildContext context) {
 return GlobalLoaderOverlay(
-  useDefaultLoading: true,
   child: MaterialApp(
     debugShowCheckedModeBanner: false,
     title: 'Flutter Demo',
@@ -70,7 +81,7 @@ return GlobalLoaderOverlay(
 
 # Customisation
 Your overlay loader widget can be any widget you want. For example you can import the package
- ![flutter_spinkit][flutter_spinkit] and customise your widget like this. To do that just pass your widget to `overlayWidget`.
+ ![flutter_spinkit][flutter_spinkit] and customise your widget like this. To do that just pass your widget to `overlayWidget` and set `useDefaultLoading` to `false`.
 
 ```dart
 class MyApp extends StatelessWidget {
@@ -82,6 +93,7 @@ class MyApp extends StatelessWidget {
         primarySwatch: Colors.blue,
       ),
       home: LoaderOverlay(
+        useDefaultLoading: false,
         overlayWidget: Center(
           child: SpinKitCubeGrid(
             color: Colors.red,
@@ -109,6 +121,7 @@ class MyApp extends StatelessWidget {
         primarySwatch: Colors.blue,
       ),
       home: LoaderOverlay(
+        useDefaultLoading: false,
         overlayWidget: Center(
           child: SpinKitCubeGrid(
             color: Colors.red,
@@ -127,23 +140,42 @@ This is a much opaque overlay:
 
 ![enter image description here](https://media.giphy.com/media/StKBJJ50luIOPjDunM/giphy.gif)
 
-Lastly you can pass some kind of a widget to be located under the loading widget. A commom use case for this is when you want to show some kind of Text to describe the state of the loading. For example you can show a String with 'Reconnecting' or 'Loading Data' under the loader.
+You may want to have several different loaders in your app. In this case just pass any widget to the `loaderOverlay.show`:
 
-To be able to do this you can just pass a widget (commonly a Text widget) to showLoaderOverlay.
+```dart
+class ReconnectingOverlay extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) => Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20.0),
+              child: CircularProgressIndicator(),
+            ),
+            SizedBox(height: 12),
+            Text(
+              'Reconnecting...',
+            ),
+          ],
+        ),
+      );
+}
 
+context.loaderOverlay.show(
+  widget: ReconnectingOverlay()
+),
 ```
-context.showLoaderOverlay(
-  widget: Text(
-    'Loading',
-    style: TextStyle(
-      color: Colors.red,
-    ),
-  ),
-)
+
+And then you can check the type before hide it:
+
+```dart
+if (context.loaderOverlay.visible && context.loaderOverlay.overlayWidgetType == ReconnectingOverlay) {
+  context.loaderOverlay.hide();
+}
 ```
 
-This code produces the following result:
-![enter image description here](https://media2.giphy.com/media/3gdAn8U9YK9XtJlcVe/giphy.gif)
+If you pass widget to `context.loaderOverlay.show`, then `defaultLoader` and `widgetOverlay` will be ignored;
 
 ## Todo
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -95,10 +95,7 @@ class ReconnectingOverlay extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 20.0),
-              child: CircularProgressIndicator(),
-            ),
+            CircularProgressIndicator(),
             SizedBox(height: 12),
             Text(
               'Reconnecting...',

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -13,6 +13,7 @@ class MyApp extends StatelessWidget {
         primarySwatch: Colors.blue,
       ),
       home: LoaderOverlay(
+        useDefaultLoading: false,
         overlayWidget: Center(
           child: SpinKitCubeGrid(
             color: Colors.red,
@@ -36,6 +37,8 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
+  bool _isLoaderVisible = false;
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -48,30 +51,59 @@ class _MyHomePageState extends State<MyHomePage> {
           children: <Widget>[
             RaisedButton(
               onPressed: () async {
-                context.showLoaderOverlay();
+                context.loaderOverlay.show();
+                setState(() {
+                  _isLoaderVisible = context.loaderOverlay.visible;
+                });
                 await Future.delayed(Duration(seconds: 2));
-                context.hideLoaderOverlay();
+                if (_isLoaderVisible) {
+                  context.loaderOverlay.hide();
+                }
+                setState(() {
+                  _isLoaderVisible = context.loaderOverlay.visible;
+                });
               },
               child: Text('Show loader overlay for 2 seconds'),
             ),
             RaisedButton(
               onPressed: () async {
-                context.showLoaderOverlay(
-                  widget: Text(
-                    'Loading',
-                    style: TextStyle(
-                      color: Colors.red,
-                    ),
-                  ),
-                );
+                context.loaderOverlay.show(widget: ReconnectingOverlay());
+                setState(() {
+                  _isLoaderVisible = context.loaderOverlay.visible;
+                });
                 await Future.delayed(Duration(seconds: 3));
-                context.hideLoaderOverlay();
+                if (_isLoaderVisible && context.loaderOverlay.overlayWidgetType == ReconnectingOverlay) {
+                  context.loaderOverlay.hide();
+                }
+                setState(() {
+                  _isLoaderVisible = context.loaderOverlay.visible;
+                });
               },
-              child: Text('Show loader overlay for 2 seconds with message'),
-            )
+              child: Text('Show custom loader overlay for 2 seconds'),
+            ),
+            Text('Is loader visible: $_isLoaderVisible'),
           ],
         ),
       ),
     );
   }
+}
+
+class ReconnectingOverlay extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) => Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20.0),
+              child: CircularProgressIndicator(),
+            ),
+            SizedBox(height: 12),
+            Text(
+              'Reconnecting...',
+            ),
+          ],
+        ),
+      );
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -80,7 +80,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.2.1"
   matcher:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -87,21 +87,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -113,56 +113,56 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
-  flutter: ">=0.1.4 <2.0.0"
+  dart: ">=2.12.0-0.0 <3.0.0"
+  flutter: ">=0.1.4"

--- a/lib/src/loader_overlay.dart
+++ b/lib/src/loader_overlay.dart
@@ -7,14 +7,13 @@ import '../loader_overlay.dart';
 /// Class that efetivally display the overlay on the screen. It's a Stateful widget
 /// so we can dispose when not needed anymore
 class LoaderOverlay extends StatefulWidget {
-  LoaderOverlay(
+  const LoaderOverlay(
       {this.overlayWidget,
-      this.useDefaultLoading = false,
+      this.useDefaultLoading = true,
       this.overlayOpacity,
       this.overlayColor = Colors.grey,
       @required this.child})
-      : assert(overlayWidget != null || useDefaultLoading != null),
-        assert(child != null);
+      : assert(child != null);
 
   final Widget overlayWidget;
   final bool useDefaultLoading;
@@ -30,7 +29,7 @@ class LoaderOverlay extends StatefulWidget {
 class _LoaderOverlayState extends State<LoaderOverlay> {
   @override
   void dispose() {
-    context.getOverlayController().dispose();
+    context.loaderOverlay.overlayController.dispose();
     super.dispose();
   }
 
@@ -39,14 +38,14 @@ class _LoaderOverlayState extends State<LoaderOverlay> {
     return OverlayControllerWidget(
       child: Builder(
         builder: (innerContext) => StreamBuilder<Map<String, dynamic>>(
-          stream: innerContext.getOverlayController().visibilityStream,
-          initialData: <String, dynamic>{
+          stream: innerContext.loaderOverlay.overlayController.visibilityStream,
+          initialData: const <String, dynamic>{
             'loading': false,
             'widget': null,
           },
           builder: (_, snapshot) {
             final isLoading = snapshot.data['loading'] as bool;
-            final widgetOverlay = snapshot.data['widget'];
+            final widgetOverlay = snapshot.data['widget'] as Widget;
             return Stack(
               children: <Widget>[
                 widget.child,
@@ -55,21 +54,14 @@ class _LoaderOverlayState extends State<LoaderOverlay> {
                         opacity: isLoading ? (widget.overlayOpacity ?? 0.4) : 0,
                         child: Container(
                           color: widget.overlayColor,
-                          child: widget.useDefaultLoading
-                              ? _getDefaultLoadingWidget()
-                              : Column(
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [
-                                    widget.overlayWidget,
-                                    Material(
-                                      color: Colors.transparent,
-                                      child: widgetOverlay,
-                                    ),
-                                  ],
-                                ),
+                          child: widgetOverlay != null
+                              ? _widgetOverlay(widgetOverlay)
+                              : widget.useDefaultLoading
+                                  ? _getDefaultLoadingWidget()
+                                  : widget.overlayWidget,
                         ),
                       )
-                    : SizedBox.shrink(),
+                    : const SizedBox.shrink(),
               ],
             );
           },
@@ -78,7 +70,16 @@ class _LoaderOverlayState extends State<LoaderOverlay> {
     );
   }
 
-  Widget _getDefaultLoadingWidget() => Center(
+  Widget _widgetOverlay(Widget widget) => SizedBox(
+        height: double.infinity,
+        width: double.infinity,
+        child: Material(
+          color: Colors.transparent,
+          child: widget,
+        ),
+      );
+
+  Widget _getDefaultLoadingWidget() => const Center(
         child: CircularProgressIndicator(),
       );
 }

--- a/lib/src/overlay_controller_widget.dart
+++ b/lib/src/overlay_controller_widget.dart
@@ -9,8 +9,7 @@ class OverlayControllerWidget extends InheritedWidget {
   static OverlayControllerWidget of(BuildContext context) =>
       context.findAncestorWidgetOfExactType<OverlayControllerWidget>();
 
-  final StreamController visibilityController =
-      StreamController<Map<String, dynamic>>();
+  final StreamController<Map<String, dynamic>> visibilityController = StreamController();
 
   Stream<Map<String, dynamic>> get visibilityStream => visibilityController.stream;
 
@@ -19,7 +18,7 @@ class OverlayControllerWidget extends InheritedWidget {
     bool loading, {
     Widget widget,
   }) =>
-      visibilityController.add({
+      visibilityController.add(<String, dynamic>{
         'loading': loading,
         'widget': widget,
       });

--- a/lib/src/overlay_controller_widget_extension.dart
+++ b/lib/src/overlay_controller_widget_extension.dart
@@ -4,15 +4,49 @@ import 'overlay_controller_widget.dart';
 
 ///Just a extension to make it cleaner to show or hide the overlay
 extension OverlayControllerWidgetExtension on BuildContext {
-  OverlayControllerWidget getOverlayController() =>
-      OverlayControllerWidget.of(this);
+  @deprecated
+  OverlayControllerWidget getOverlayController() => OverlayControllerWidget.of(this);
 
   ///Extension created to show the overlay
+  @deprecated
   void showLoaderOverlay({
     Widget widget,
   }) =>
       getOverlayController().setOverlayVisible(true, widget: widget);
 
   ///Extension created to hide the overlay
+  @deprecated
   void hideLoaderOverlay() => getOverlayController().setOverlayVisible(false);
+
+  _OverlayExtensionHelper get loaderOverlay => _OverlayExtensionHelper(OverlayControllerWidget.of(this));
+}
+
+class _OverlayExtensionHelper {
+  static final _OverlayExtensionHelper _singleton = _OverlayExtensionHelper._internal();
+  OverlayControllerWidget _overlayController;
+
+  Widget _widget;
+  bool _visible;
+
+  OverlayControllerWidget get overlayController => _overlayController;
+  bool get visible => _visible ?? false;
+
+  factory _OverlayExtensionHelper(OverlayControllerWidget overlayController) {
+    _singleton._overlayController = overlayController;
+    return _singleton;
+  }
+  _OverlayExtensionHelper._internal();
+
+  Type get overlayWidgetType => _widget?.runtimeType;
+
+  void show({Widget widget}) {
+    _widget = widget;
+    _visible = true;
+    _overlayController.setOverlayVisible(_visible, widget: _widget);
+  }
+
+  void hide() {
+    _visible = false;
+    _overlayController.setOverlayVisible(_visible);
+  }
 }

--- a/lib/src/overlay_controller_widget_extension.dart
+++ b/lib/src/overlay_controller_widget_extension.dart
@@ -4,18 +4,18 @@ import 'overlay_controller_widget.dart';
 
 ///Just a extension to make it cleaner to show or hide the overlay
 extension OverlayControllerWidgetExtension on BuildContext {
-  @deprecated
+  @Deprecated('Use context.loaderOverlay instead')
   OverlayControllerWidget getOverlayController() => OverlayControllerWidget.of(this);
 
   ///Extension created to show the overlay
-  @deprecated
+  @Deprecated('Use context.loaderOverlay.show() instead')
   void showLoaderOverlay({
     Widget widget,
   }) =>
       getOverlayController().setOverlayVisible(true, widget: widget);
 
   ///Extension created to hide the overlay
-  @deprecated
+  @Deprecated('Use context.loaderOverlay.hide() instead')
   void hideLoaderOverlay() => getOverlayController().setOverlayVisible(false);
 
   _OverlayExtensionHelper get loaderOverlay => _OverlayExtensionHelper(OverlayControllerWidget.of(this));

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,49 +7,49 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,21 +66,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -92,55 +92,55 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
+  dart: ">=2.12.0-0.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: loader_overlay
 description: A simple package to simplify screen management. When loading any async task, this package prevent the user from interacting with the screen until the async task finishes.
-version: 1.2.0
+version: 1.2.1
 homepage: https://github.com/rodrigobastosv/loading_overlay
 
 environment:
@@ -14,39 +14,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #  - images/a_dot_burr.jpeg
-  #  - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages


### PR DESCRIPTION
Continuing this [issue](https://github.com/rodrigobastosv/loading_overlay/issues/7). Suggesting this changes:

* `context.showLoaderOverlay` and `context.hideLoaderOverlay` marked as depricated because incapsulated to `context.loaderOverlay` 
* Widget that you pass to `context.loaderOverlay.show` (if so) will be shown instead of `widgetOverlay`
* Added `context.loaderOverlay.visible`
* Added `context.loaderOverlay.overlayWidgetType`
* `useDefaultLoading` set to `true` by default