### PR TITLE
don't lookup deactivated widget's ancestors

### DIFF
--- a/lib/src/loader_overlay.dart
+++ b/lib/src/loader_overlay.dart
@@ -27,9 +27,19 @@ class LoaderOverlay extends StatefulWidget {
 
 // Has the Center CircularProgressIndicator as the default loader
 class _LoaderOverlayState extends State<LoaderOverlay> {
+  OverlayControllerWidget? _overlayControllerWidget;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    setState(() {
+      _overlayControllerWidget = OverlayControllerWidget.of(context);
+    });
+  }
+
   @override
   void dispose() {
-    context.loaderOverlay.overlayController.dispose();
+    _overlayControllerWidget?.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
before: 

```
flutter ( 7559): Error :  Looking up a deactivated widget's ancestor is unsafe.
I/flutter ( 7559): At this point the state of the widget's element tree is no longer stable.
I/flutter ( 7559): To safely refer to a widget's ancestor in its dispose() method, save a reference to the ancestor by calling dependOnInheritedWidgetOfExactType() in the widget's didChangeDependencies() method.
I/flutter ( 7559): StackTrace :  #0      Element._debugCheckStateIsActiveForAncestorLookup.<anonymous closure>
package:flutter/…/widgets/framework.dart:3936
I/flutter ( 7559): #1      Element._debugCheckStateIsActiveForAncestorLookup
package:flutter/…/widgets/framework.dart:3950
I/flutter ( 7559): #2      Element.findAncestorWidgetOfExactType
package:flutter/…/widgets/framework.dart:3989
I/flutter ( 7559): #3      OverlayControllerWidget.of
package:loader_overlay/src/overlay_controller_widget.dart:10
I/flutter ( 7559): #4      OverlayControllerWidgetExtension.loaderOverlay
package:loader_overlay/src/overlay_controller_widget_extension.dart:23
I/flutter ( 7559): #5      _LoaderOverlayState.dispose
package:loader_overlay/src/loader_overlay.dart:32
I/flutter ( 7559): #6      StatefulElement.unmount
package:flutter/…/widgets/framework.dart:4793
I/flutter ( 7559): #7      _InactiveElements._unmount
package:flutter/…/widgets/framework.dart:1844
I/flutter ( 7559): #8      _InactiveElements._unmount.<anonymous closure>
package:flutter/…/widgets/framework.dart:184
...
```