### PR TITLE
Add the possibility to close loader when backButton is pressed

### DIFF
--- a/lib/src/global_loader_overlay.dart
+++ b/lib/src/global_loader_overlay.dart
@@ -12,6 +12,7 @@ class GlobalLoaderOverlay extends StatefulWidget {
     this.overlayOpacity,
     this.overlayWidget,
     this.disableBackButton = true,
+    this.closeOnBackButton = false,
     this.textDirection = TextDirection.ltr,
   }) : super(key: key);
 
@@ -34,6 +35,9 @@ class GlobalLoaderOverlay extends StatefulWidget {
   /// Whether or not to disable the back button while loading.
   final bool disableBackButton;
 
+  //Hide the loader when back button pressed
+  final bool closeOnBackButton;
+
   /// TextDirection of the app. This is generaly used when putting [LoaderOverlay] above MaterialApp.
   final TextDirection textDirection;
 
@@ -52,6 +56,7 @@ class _GlobalLoaderOverlayState extends State<GlobalLoaderOverlay> {
         overlayOpacity: widget.overlayOpacity,
         overlayWidget: widget.overlayWidget,
         disableBackButton: widget.disableBackButton,
+        closeOnBackButton: widget.closeOnBackButton,
         child: widget.child,
       ),
     );

--- a/lib/src/loader_overlay.dart
+++ b/lib/src/loader_overlay.dart
@@ -18,6 +18,7 @@ class LoaderOverlay extends StatefulWidget {
     this.overlayWholeScreen = true,
     this.overlayHeight,
     this.overlayWidth,
+    this.closeOnBackButton = false,
     required this.child,
   }) : super(key: key);
 
@@ -36,6 +37,9 @@ class LoaderOverlay extends StatefulWidget {
 
   /// Whether or not to disable the back button while loading.
   final bool disableBackButton;
+  
+  //Hide the loader when back button pressed
+  final bool closeOnBackButton;
 
   /// This should be false if you want to have full control of the size of the overlay.
   /// This is generaly used in conjunction with [overlayHeight] and [overlayWidth] to
@@ -90,6 +94,9 @@ class _LoaderOverlayState extends State<LoaderOverlay> {
   }
 
   bool myInterceptor(bool stopDefaultButtonEvent, RouteInfo info) {
+    if (context.loaderOverlay.visible && widget.closeOnBackButton) {
+      context.loaderOverlay.hide();
+    }
     return widget.disableBackButton;
   }
 


### PR DESCRIPTION
Adding the possibility to close the loader (in case of failure or something else) when backbutton is pressed.
Default value is false to not break already implemented use of your plugin :)

PS: can you please add more information about GlobalLoader and all parameters in your readme ? It will be usefull and easier than searching in package comments ;) 