### PR TITLE
temporary fix for not showing opacity on iOS in flutter 3.13.0

### DIFF
--- a/lib/src/loader_overlay.dart
+++ b/lib/src/loader_overlay.dart
@@ -184,27 +184,21 @@ class _LoaderOverlayState extends State<LoaderOverlay> {
   List<Widget> _getLoadingWidget(bool isLoading, Widget? widgetOverlay) => [
         WillPopScope(
           onWillPop: () async => !widget.disableBackButton,
-          child: Opacity(
-            key: LoaderOverlay.opacityWidgetKey,
-            opacity: isLoading
-                ? (widget.overlayOpacity ?? LoaderOverlay.defaultOpacityValue)
-                : 0,
-            child: widget.overlayWholeScreen
-                ? Container(
+          child: widget.overlayWholeScreen
+              ? Container(
+                  key: LoaderOverlay.containerForOverlayColorKey,
+                  color:
+                      widget.overlayColor ?? LoaderOverlay.defaultOverlayColor,
+                )
+              : Center(
+                  child: Container(
+                    height: widget.overlayHeight,
+                    width: widget.overlayWidth,
                     key: LoaderOverlay.containerForOverlayColorKey,
                     color: widget.overlayColor ??
                         LoaderOverlay.defaultOverlayColor,
-                  )
-                : Center(
-                    child: Container(
-                      height: widget.overlayHeight,
-                      width: widget.overlayWidth,
-                      key: LoaderOverlay.containerForOverlayColorKey,
-                      color: widget.overlayColor ??
-                          LoaderOverlay.defaultOverlayColor,
-                    ),
                   ),
-          ),
+                ),
         ),
         if (widgetOverlay != null)
           _widgetOverlay(widgetOverlay)


### PR DESCRIPTION
Flutter version 3.13.0 has a bug on ios that causes the opacity widget to not work. Until this is fixed, with this commit, we can ask the users to specify the opacity when defining the color. We can revert this commit in the next flutter release.

```
Ex:
GlobalLoaderOverlay(
          overlayOpacity: 0.5, // This is not
          useDefaultLoading: false,
          overlayWidget: const Center(
            child: CircularProgressIndicator(),
          ),
          overlayColor: Colors.black.withOpacity(0.5),//<<<<<<<<<
          child: const Home(),
        ),
```