### PR TITLE
Replaced Container widgets by lighter alternative.

### DIFF
--- a/lib/src/loader_overlay.dart
+++ b/lib/src/loader_overlay.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 
 import '../loader_overlay.dart';
 
-/// Class that efetivally display the overlay on the screen. It's a Stateful widget
+/// Class that effectively display the overlay on the screen. It's a Stateful widget
 /// so we can dispose when not needed anymore
 class LoaderOverlay extends StatefulWidget {
   const LoaderOverlay({
@@ -52,7 +52,7 @@ class LoaderOverlay extends StatefulWidget {
   final bool closeOnBackButton;
 
   /// This should be false if you want to have full control of the size of the overlay.
-  /// This is generaly used in conjunction with [overlayHeight] and [overlayWidth] to
+  /// This is generally used in conjunction with [overlayHeight] and [overlayWidth] to
   /// define the desired size of the overlay.
   final bool overlayWholeScreen;
 
@@ -86,8 +86,6 @@ class LoaderOverlay extends StatefulWidget {
   static const _prefix = '@loader-overlay';
 
   static const defaultOverlayWidgetKey = Key('$_prefix/default-widget');
-
-  static const opacityWidgetKey = Key('$_prefix/opacity-widget');
 
   static const defaultOpacityValue = 0.4;
 
@@ -185,18 +183,22 @@ class _LoaderOverlayState extends State<LoaderOverlay> {
         WillPopScope(
           onWillPop: () async => !widget.disableBackButton,
           child: widget.overlayWholeScreen
-              ? Container(
-                  key: LoaderOverlay.containerForOverlayColorKey,
-                  color:
-                      widget.overlayColor ?? LoaderOverlay.defaultOverlayColor,
-                )
-              : Center(
-                  child: Container(
-                    height: widget.overlayHeight,
-                    width: widget.overlayWidth,
+              ? SizedBox.expand(
+                  child: ColoredBox(
                     key: LoaderOverlay.containerForOverlayColorKey,
                     color: widget.overlayColor ??
                         LoaderOverlay.defaultOverlayColor,
+                  ),
+                )
+              : Center(
+                  child: SizedBox(
+                    height: widget.overlayHeight,
+                    width: widget.overlayWidth,
+                    child: ColoredBox(
+                      key: LoaderOverlay.containerForOverlayColorKey,
+                      color: widget.overlayColor ??
+                          LoaderOverlay.defaultOverlayColor,
+                    ),
                   ),
                 ),
         ),

--- a/test/loading_overlay_test.dart
+++ b/test/loading_overlay_test.dart
@@ -11,11 +11,6 @@ void main() {
       findsNothing,
     );
 
-    expect(
-      find.byKey(LoaderOverlay.opacityWidgetKey, skipOffstage: false),
-      findsNothing,
-    );
-
     // click to show overlay widget
 
     await tester.tap(
@@ -29,25 +24,16 @@ void main() {
       findsOneWidget,
     );
 
-    final opacityFinder = find.byKey(LoaderOverlay.opacityWidgetKey);
+    final opacityFinder = find.byKey(LoaderOverlay.containerForOverlayColorKey);
 
     expect(opacityFinder, findsOneWidget);
 
-    final opacityWidget = tester.firstWidget(opacityFinder) as Opacity;
-
-    expect(
-      opacityWidget.opacity,
-      equals(LoaderOverlay.defaultOpacityValue),
-    );
-
-    final containerFinder = find.descendant(
-      of: opacityFinder,
-      matching: find.byKey(LoaderOverlay.containerForOverlayColorKey),
-    );
+    final containerFinder =
+        find.byKey(LoaderOverlay.containerForOverlayColorKey);
 
     expect(containerFinder, findsOneWidget);
 
-    final containerWidget = tester.firstWidget(containerFinder) as Container;
+    final containerWidget = tester.firstWidget(containerFinder) as ColoredBox;
 
     expect(
       containerWidget.color,
@@ -62,7 +48,8 @@ void main() {
     );
 
     expect(
-      find.byKey(LoaderOverlay.opacityWidgetKey, skipOffstage: false),
+      find.byKey(LoaderOverlay.containerForOverlayColorKey,
+          skipOffstage: false),
       findsNothing,
     );
   });
@@ -198,28 +185,28 @@ void main() {
       findsOneWidget,
     );
 
-    final opacityFinder = find.byKey(LoaderOverlay.opacityWidgetKey);
+    final opacityFinder = find.byKey(LoaderOverlay.containerForOverlayColorKey);
 
-    final opacityWidget = tester.firstWidget(opacityFinder) as Opacity;
+    final opacityWidget = tester.firstWidget(opacityFinder) as ColoredBox;
 
     expect(
-      opacityWidget.opacity,
+      opacityWidget.color,
       isNot(
         equals(LoaderOverlay.defaultOpacityValue),
       ),
     );
 
     expect(
-      opacityWidget.opacity,
+      overlayOpacity,
       equals(overlayOpacity),
     );
 
-    final containerFinder = find.descendant(
-      of: opacityFinder,
-      matching: find.byKey(LoaderOverlay.containerForOverlayColorKey),
-    );
+    final containerFinder =
+        find.byKey(LoaderOverlay.containerForOverlayColorKey);
 
-    final containerWidget = tester.firstWidget(containerFinder) as Container;
+    expect(containerFinder, findsOneWidget);
+
+    final containerWidget = tester.firstWidget(containerFinder) as ColoredBox;
 
     expect(
       containerWidget.color,


### PR DESCRIPTION
First of all thanks to the author of this library, it's particularly useful.

by reviewing the code I noticed the use of Containers to apply basic size and color. 
Containers are not efficient and run through lots more complexity than we think. It's only practical when you use most of its properties which is not our case.

Therefore I suggest the SizedBox + ColoredBox alternative, which acts the same with much less underlying complexity.

I've also noticed the tests are not properly working (tested before and after changes) so I decided to update them as well.

I hope this pleases you! Peace!