### PR TITLE
`GlobalLoaderOverlay` now forward the `useBackButtonInterceptor` parameter

### DIFF
--- a/lib/src/global_loader_overlay.dart
+++ b/lib/src/global_loader_overlay.dart
@@ -103,6 +103,7 @@ class _GlobalLoaderOverlayState extends State<GlobalLoaderOverlay> {
         switchOutCurve: widget.switchOutCurve,
         transitionBuilder: widget.transitionBuilder,
         layoutBuilder: widget.layoutBuilder,
+        useBackButtonInterceptor: widget.useBackButtonInterceptor,
         child: widget.child,
       ),
     );


### PR DESCRIPTION
In the `GlobalLoaderOverlay` widget, the `useBackButtonInterceptor` parameter is now correctly forwarded to the `LoaderOverlay`.

Fixes https://github.com/rodrigobastosv/loading_overlay/issues/66