### PR TITLE
remove useDefaultLoading in favor of overlayWidgetBuilder being null

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -75,45 +75,69 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.4"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   loader_overlay:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "3.0.3"
+    version: "4.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -163,10 +187,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   vector_math:
     dependency: transitive
     description:
@@ -175,14 +199,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      name: vm_service
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "14.2.1"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
-  flutter: ">=2.0.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/global_loader_overlay.dart
+++ b/lib/src/global_loader_overlay.dart
@@ -9,7 +9,8 @@ class GlobalLoaderOverlay extends StatefulWidget {
     Key? key,
     this.textDirection = TextDirection.ltr,
     this.overlayWidgetBuilder,
-    this.useDefaultLoading = true,
+    @Deprecated('Use `overlayWidgetBuilder == null` instead')
+    this.useDefaultLoading,
     this.overlayColor,
     this.disableBackButton = true,
     this.overlayWholeScreen = true,
@@ -30,10 +31,10 @@ class GlobalLoaderOverlay extends StatefulWidget {
 
   /// The widget of the overlay. This is great if you want to insert your own widget to serve as
   /// an overlay.
-  final Widget Function(dynamic progress)? overlayWidgetBuilder;
+  final OverlayWidgetBuilder? overlayWidgetBuilder;
 
-  /// Whether or not to use a default loading if none is provided.
-  final bool useDefaultLoading;
+  @Deprecated('Use `overlayWidgetBuilder == null` instead')
+  final bool? useDefaultLoading;
 
   /// The color of the overlay
   final Color? overlayColor;
@@ -71,10 +72,10 @@ class GlobalLoaderOverlay extends StatefulWidget {
   final Curve switchOutCurve;
 
   /// The transition builder for the overlay
-  final Widget Function(Widget, Animation<double>) transitionBuilder;
+  final OverlayTransitionBuilder transitionBuilder;
 
   /// The layout builder for the overlay
-  final Widget Function(Widget?, List<Widget>) layoutBuilder;
+  final OverlayLayoutBuilder layoutBuilder;
 
   /// TextDirection of the app. This is generaly used when putting [LoaderOverlay] above MaterialApp.
   final TextDirection textDirection;
@@ -90,7 +91,6 @@ class _GlobalLoaderOverlayState extends State<GlobalLoaderOverlay> {
       textDirection: widget.textDirection,
       child: LoaderOverlay(
         overlayWidgetBuilder: widget.overlayWidgetBuilder,
-        useDefaultLoading: widget.useDefaultLoading,
         overlayColor: widget.overlayColor,
         disableBackButton: widget.disableBackButton,
         overlayWholeScreen: widget.overlayWholeScreen,

--- a/test/loading_overlay_test.dart
+++ b/test/loading_overlay_test.dart
@@ -119,7 +119,6 @@ void main() {
     await tester.pumpWidget(
       TestApp(
         overlayWidgetBuilder: (progress) => Container(key: containerKey),
-        useDefaultLoading: false,
       ),
     );
 
@@ -264,12 +263,10 @@ class TestApp extends StatelessWidget {
   const TestApp({
     Key? key,
     this.overlayWidgetBuilder,
-    this.useDefaultLoading = LoaderOverlay.useDefaultLoadingValue,
     this.overlayColor,
   }) : super(key: key);
 
   final Widget Function(dynamic progress)? overlayWidgetBuilder;
-  final bool useDefaultLoading;
   final Color? overlayColor;
 
   static const showHideOverlayIconKey = Key('@test/show-hide-overlay');
@@ -281,7 +278,6 @@ class TestApp extends StatelessWidget {
     return MaterialApp(
       home: LoaderOverlay(
         overlayWidgetBuilder: overlayWidgetBuilder,
-        useDefaultLoading: useDefaultLoading,
         overlayColor: overlayColor ?? LoaderOverlay.defaultOverlayColor,
         child: Scaffold(
           body: Column(


### PR DESCRIPTION
To use a custom overlayWidgetBuilder, you need to set `useDefaultLoading` to `false explicitly`. This is redundant because the builder is already an optional parameter, and useDefaultLoading is set to false by default.

This pull request removes the `useDefaultLoading` parameter altogether. Instead, if `overlayWidgetBuilder` is `null`, the overlay will automatically fall back to the default widget. This change simplifies the API and improves usability.